### PR TITLE
Added kCGImagePropertyGIFHasGlobalColorMap for raising the quality

### DIFF
--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -58,15 +58,17 @@ public struct Regift {
     
     /// Get the URL of the GIF created with the attributes provided in the initializer.
     public func createGif() -> NSURL? {
-        let fileProperties = [kCGImagePropertyGIFDictionary as String:
-            [
-                kCGImagePropertyGIFLoopCount as String: loopCount
-            ]]
+
+        let fileProperties = [kCGImagePropertyGIFDictionary as String:[
+            kCGImagePropertyGIFLoopCount as String: NSNumber(int: Int32(loopCount))],
+            kCGImagePropertyGIFHasGlobalColorMap as String: NSValue(nonretainedObject: true)
+        ]
         
-        let frameProperties = [kCGImagePropertyGIFDictionary as String:
-            [
-                kCGImagePropertyGIFDelayTime as String: delayTime
-            ]]
+        let frameProperties = [
+            kCGImagePropertyGIFDictionary as String:[
+                kCGImagePropertyGIFDelayTime as String:delayTime
+            ]
+        ]
         
         let asset = AVURLAsset(URL: sourceFileURL, options: nil)
         


### PR DESCRIPTION
I found a problem.

In this library, GIF animation file of quality is bad when current `fileProperties` is only `kCGImagePropertyGIFLoopCount`.
So, I add a property `kCGImagePropertyGIFHasGlobalColorMap` for file quality.

I tried two pattern that `kCGImagePropertyGIFHasGlobalColorMap` is true and false.

The results are as follow.
- before : kCGImagePropertyGIFHasGlobalColorMap is false
- after : kCGImagePropertyGIFHasGlobalColorMap is true
### patter 1

| before | after |
| --- | --- |
| ![2_1](https://cloud.githubusercontent.com/assets/193569/13570841/2984a194-e4b4-11e5-9a72-2c1b7032c4dc.gif) | ![2_2](https://cloud.githubusercontent.com/assets/193569/13570842/2989a05e-e4b4-11e5-8561-9e87391ec2b0.gif) |
### patter 2

| before | after |
| --- | --- |
| ![3_0](https://cloud.githubusercontent.com/assets/193569/13570858/4b5138d2-e4b4-11e5-93c5-fe11f77d0bfa.gif) | ![3_1](https://cloud.githubusercontent.com/assets/193569/13570857/4b505d22-e4b4-11e5-8a3e-853c17c502d8.gif) |
