### PR TITLE
Add support for trimmed GIFs, and other improvements

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,10 +29,10 @@ import Regift
 ```swift
 let videoURL   = ...
 let frameCount = 16
-let delayTime  = 0.2
+let delayTime  = Float(0.2)
 let loopCount  = 0    // 0 means loop forever
 
-let regift = Regift(sourceFileURL: videoURL, frameCount: frameCount, delayTime, loopCount: loopCount)
+let regift = Regift(sourceFileURL: videoURL, frameCount: frameCount, delayTime: delayTime, loopCount: loopCount)
 print("Gif saved to \(regift.createGif())")
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,8 @@ Regift is available through [Carthage](https://github.com/Carthage/Carthage).
 import Regift
 ```
 
+Synchronous GIF creation:
+
 ```swift
 let videoURL   = ...
 let frameCount = 16
@@ -34,6 +36,34 @@ let loopCount  = 0    // 0 means loop forever
 
 let regift = Regift(sourceFileURL: videoURL, frameCount: frameCount, delayTime: delayTime, loopCount: loopCount)
 print("Gif saved to \(regift.createGif())")
+
+let startTime = Float(30)
+let duration  = Float(15)
+let frameRate = 15
+
+let trimmedRegift = Regift(sourceFileURL: URL, startTime: startTime, duration: duration, frameRate: frameRate, loopCount: loopCount)
+print("Gif saved to \(trimmedRegift.createGif())")
+```
+
+Asynchronous GIF creation:
+
+```swift
+let videoURL   = ...
+let frameCount = 16
+let delayTime  = Float(0.2)
+let loopCount  = 0    // 0 means loop forever
+
+Regift.createGIFFromSource(videoURL, frameCount: frameCount, delayTime: delayTime) { (result) in
+    print("Gif saved to \(result)")
+}
+
+let startTime = Float(30)
+let duration  = Float(15)
+let frameRate = 15
+
+Regift.createGIFFromSource(videoURL, startTime: startTime, duration: duration, frameRate: frameRate) { (result) in
+    print("Gif saved to \(result)")
+}
 ```
 
 ## Acknowledgements

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -34,9 +34,9 @@ private struct Group {
     func wait() { dispatch_group_wait(group, DISPATCH_TIME_FOREVER) }
 }
 
-/// Easily convert a video to a GIF.
+/// Easily convert a video to a GIF. It can convert the whole thing, or you can choose a section to trim out.
 ///
-/// Usage:
+/// Synchronous Usage:
 ///
 ///      let regift = Regift(sourceFileURL: movieFileURL, frameCount: 24, delayTime: 0.5, loopCount: 7)
 ///      print(regift.createGif())
@@ -45,6 +45,18 @@ private struct Group {
 ///
 ///      let trimmedRegift = Regift(sourceFileURL: movieFileURL, startTime: 30, duration: 15, frameRate: 15)
 ///      print(trimmedRegift.createGif())
+///
+/// Asynchronous Usage:
+///
+///      let regift = Regift.createGIFFromSource(movieFileURL, frameCount: 24, delayTime: 0.5, loopCount: 7) { (result) in
+///          print(result)
+///      }
+///
+///      // OR
+///
+///      let trimmedRegift = Regift.createGIFFromSource(movieFileURL, startTime: 30, duration: 15, frameRate: 15) { (result) in
+///          print(result)
+///      }
 ///
 public struct Regift {
 

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -39,7 +39,7 @@ private struct Group {
 /// Usage:
 ///
 ///      let regift = Regift(sourceFileURL: movieFileURL, frameCount: 24, delayTime: 0.5, loopCount: 7)
-///      print(regift.gifURL)
+///      print(regift.createGif())
 ///
 public struct Regift {
     private struct Constants {
@@ -51,10 +51,19 @@ public struct Regift {
     /// A reference to the asset we are converting.
     private var asset: AVAsset
 
+    /// The url for the source file.
     private let sourceFileURL: NSURL
+
+    /// The number of frames we are going to use to create the gif.
     private let frameCount: Int
+
+    /// The amount of time each frame will remain on screen in the gif.
     private let delayTime: Float
+
+    /// The number of times the gif will loop (0 is infinite).
     private let loopCount: Int
+
+    /// The destination path for the generated file.
     private var destinationFileURL: NSURL?
     
     /// Create a GIF from a movie stored at the given URL.

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -54,6 +54,9 @@ public struct Regift {
     /// The url for the source file.
     private let sourceFileURL: NSURL
 
+    /// The total length of the movie, in seconds.
+    private var movieLength: Float
+
     /// The number of frames we are going to use to create the gif.
     private let frameCount: Int
 
@@ -74,6 +77,7 @@ public struct Regift {
     public init(sourceFileURL: NSURL, destinationFileURL: NSURL?, frameCount: Int, delayTime: Float, loopCount: Int = 0) {
         self.sourceFileURL = sourceFileURL
         self.asset = AVURLAsset(URL: sourceFileURL, options: nil)
+        self.movieLength = Float(asset.duration.value) / Float(asset.duration.timescale)
         self.delayTime = delayTime
         self.loopCount = loopCount
         self.destinationFileURL = destinationFileURL
@@ -97,9 +101,6 @@ public struct Regift {
                 kCGImagePropertyGIFDelayTime as String:delayTime
             ]
         ]
-        
-        // The total length of the movie, in seconds.
-        let movieLength = Float(asset.duration.value) / Float(asset.duration.timescale)
 
         // How far along the video track we want to move, in seconds.
         let increment = Float(movieLength) / Float(frameCount)

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -47,6 +47,70 @@ private struct Group {
 ///      print(trimmedRegift.createGif())
 ///
 public struct Regift {
+
+    // Static conversion methods, for convenient and easy-to-use API:
+
+    /**
+        Create a GIF from a movie stored at the given URL. This converts the whole video to a GIF meeting the requested output parameters.
+
+        - parameters:
+            - sourceFileURL: The source file to create the GIF from.
+            - destinationFileURL: An optional destination file to write the GIF to. If you don't include this, a default path will be provided.
+            - frameCount: The number of frames to include in the gif; each frame has the same duration and is spaced evenly over the video.
+            - delayTime: The amount of time each frame exists for in the GIF.
+            - loopCount: The number of times the GIF will repeat. This defaults to `0`, which means that the GIF will repeat infinitely.
+            - completion: A block that will be called when the GIF creation is completed. The `result` parameter provides the path to the file, or will be `nil` if there was an error.
+    */
+    public static func createGIFFromSource(
+        sourceFileURL: NSURL,
+        destinationFileURL: NSURL? = nil,
+        frameCount: Int,
+        delayTime: Float,
+        loopCount: Int = 0,
+        completion: (result: NSURL?) -> Void) {
+            let gift = Regift(
+                sourceFileURL: sourceFileURL,
+                destinationFileURL: destinationFileURL,
+                frameCount: frameCount,
+                delayTime: delayTime,
+                loopCount: loopCount
+            )
+
+            completion(result: gift.createGif())
+    }
+
+    /**
+        Create a GIF from a movie stored at the given URL. This allows you to choose a start time and duration in the source material that will be used to create the GIF which meets the output parameters.
+
+        - parameters:
+            - sourceFileURL: The source file to create the GIF from.
+            - destinationFileURL: An optional destination file to write the GIF to. If you don't include this, a default path will be provided.
+            - startTime: The time in seconds in the source material at which you want the GIF to start.
+            - duration: The duration in seconds that you want to pull from the source material.
+            - frameRate: The desired frame rate of the outputted GIF.
+            - loopCount: The number of times the GIF will repeat. This defaults to `0`, which means that the GIF will repeat infinitely.
+            - completion: A block that will be called when the GIF creation is completed. The `result` parameter provides the path to the file, or will be `nil` if there was an error.
+    */
+    public static func createGIFFromSource(
+        sourceFileURL: NSURL,
+        destinationFileURL: NSURL? = nil,
+        startTime: Float,
+        duration: Float,
+        frameRate: Int,
+        loopCount: Int = 0,
+        completion: (result: NSURL?) -> Void) {
+            let gift = Regift(
+                sourceFileURL: sourceFileURL,
+                destinationFileURL: destinationFileURL,
+                startTime: startTime,
+                duration: duration,
+                frameRate: frameRate,
+                loopCount: loopCount
+            )
+
+            completion(result: gift.createGif())
+    }
+
     private struct Constants {
         static let FileName = "regift.gif"
         static let TimeInterval: Int32 = 600

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -90,7 +90,7 @@ public struct Regift {
             - delayTime: The amount of time each frame exists for in the GIF.
             - loopCount: The number of times the GIF will repeat. This defaults to `0`, which means that the GIF will repeat infinitely.
      */
-    public init(sourceFileURL: NSURL, destinationFileURL: NSURL?, frameCount: Int, delayTime: Float, loopCount: Int = 0) {
+    public init(sourceFileURL: NSURL, destinationFileURL: NSURL? = nil, frameCount: Int, delayTime: Float, loopCount: Int = 0) {
         self.sourceFileURL = sourceFileURL
         self.asset = AVURLAsset(URL: sourceFileURL, options: nil)
         self.movieLength = Float(asset.duration.value) / Float(asset.duration.timescale)
@@ -112,7 +112,7 @@ public struct Regift {
             - frameRate: The desired frame rate of the outputted GIF.
             - loopCount: The number of times the GIF will repeat. This defaults to `0`, which means that the GIF will repeat infinitely.
      */
-    public init(sourceFileURL: NSURL, destinationFileURL: NSURL?, startTime: Float, duration: Float, frameRate: Int, loopCount: Int = 0) {
+    public init(sourceFileURL: NSURL, destinationFileURL: NSURL? = nil, startTime: Float, duration: Float, frameRate: Int, loopCount: Int = 0) {
         self.sourceFileURL = sourceFileURL
         self.asset = AVURLAsset(URL: sourceFileURL, options: nil)
         self.destinationFileURL = destinationFileURL
@@ -129,14 +129,6 @@ public struct Regift {
         self.movieLength = Float(asset.duration.value) / Float(asset.duration.timescale)
 
         self.loopCount = loopCount
-    }
-    
-    public init(sourceFileURL: NSURL, frameCount: Int, delayTime: Float, loopCount: Int = 0) {
-        self.init(sourceFileURL:sourceFileURL, destinationFileURL:nil, frameCount:frameCount, delayTime:delayTime, loopCount:loopCount)
-    }
-
-    public init(sourceFileURL: NSURL, startTime: Float, duration: Float, frameRate: Int, loopCount: Int = 0) {
-        self.init(sourceFileURL: sourceFileURL, destinationFileURL: nil, startTime: startTime, duration: duration, frameRate: frameRate, loopCount: loopCount)
     }
 
     /**

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -54,6 +54,12 @@ public struct Regift {
     /// The url for the source file.
     private let sourceFileURL: NSURL
 
+    /// The point in time in the source which we will start from.
+    private var startTime: Float = 0
+
+    /// The desired duration of the gif.
+    private var duration: Float
+
     /// The total length of the movie, in seconds.
     private var movieLength: Float
 
@@ -78,6 +84,7 @@ public struct Regift {
         self.sourceFileURL = sourceFileURL
         self.asset = AVURLAsset(URL: sourceFileURL, options: nil)
         self.movieLength = Float(asset.duration.value) / Float(asset.duration.timescale)
+        self.duration = movieLength
         self.delayTime = delayTime
         self.loopCount = loopCount
         self.destinationFileURL = destinationFileURL
@@ -103,13 +110,13 @@ public struct Regift {
         ]
 
         // How far along the video track we want to move, in seconds.
-        let increment = Float(movieLength) / Float(frameCount)
+        let increment = Float(duration) / Float(frameCount)
         
         // Add each of the frames to the buffer
         var timePoints: [TimePoint] = []
         
         for frameNumber in 0 ..< frameCount {
-            let seconds: Float64 = Float64(increment) * Float64(frameNumber)
+            let seconds: Float64 = Float64(startTime) + (Float64(increment) * Float64(frameNumber))
             let time = CMTimeMakeWithSeconds(seconds, Constants.TimeInterval)
             
             timePoints.append(time)

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -80,11 +80,16 @@ public struct Regift {
     /// The destination path for the generated file.
     private var destinationFileURL: NSURL?
     
-    /// Create a GIF from a movie stored at the given URL.
-    ///
-    /// :param: frameCount The number of frames to include in the gif; each frame has the same duration and is spaced evenly over the video.
-    /// :param: delayTime The amount of time each frame exists for in the GIF.
-    /// :param: loopCount The number of times the GIF will repeat. This defaults to 0, which means that the GIF will repeat infinitely.
+    /**
+        Create a GIF from a movie stored at the given URL. This converts the whole video to a GIF meeting the requested output parameters.
+
+        - parameters:
+            - sourceFileURL: The source file to create the GIF from.
+            - destinationFileURL: An optional destination file to write the GIF to. If you don't include this, a default path will be provided.
+            - frameCount: The number of frames to include in the gif; each frame has the same duration and is spaced evenly over the video.
+            - delayTime: The amount of time each frame exists for in the GIF.
+            - loopCount: The number of times the GIF will repeat. This defaults to `0`, which means that the GIF will repeat infinitely.
+     */
     public init(sourceFileURL: NSURL, destinationFileURL: NSURL?, frameCount: Int, delayTime: Float, loopCount: Int = 0) {
         self.sourceFileURL = sourceFileURL
         self.asset = AVURLAsset(URL: sourceFileURL, options: nil)
@@ -96,12 +101,17 @@ public struct Regift {
         self.frameCount = frameCount
     }
 
-    /// Create a GIF from a movie stored at the given URL, trimmed to a specific section.
-    ///
-    /// :param: startTime The time at which to start the gif, trimmed out of the source file.
-    /// :param: duration The length of time from startTime to include in the trimmed file.
-    /// :param: frameRate The framerate desired for the resultant gif.
-    /// :param: loopCount The number of times the GIF will repeat. This defaults to 0, which means that the GIF will repeat infinitely.
+    /**
+        Create a GIF from a movie stored at the given URL. This allows you to choose a start time and duration in the source material that will be used to create the GIF which meets the output parameters.
+
+        - parameters:
+            - sourceFileURL: The source file to create the GIF from.
+            - destinationFileURL: An optional destination file to write the GIF to. If you don't include this, a default path will be provided.
+            - startTime: The time in seconds in the source material at which you want the GIF to start.
+            - duration: The duration in seconds that you want to pull from the source material.
+            - frameRate: The desired frame rate of the outputted GIF.
+            - loopCount: The number of times the GIF will repeat. This defaults to `0`, which means that the GIF will repeat infinitely.
+     */
     public init(sourceFileURL: NSURL, destinationFileURL: NSURL?, startTime: Float, duration: Float, frameRate: Int, loopCount: Int = 0) {
         self.sourceFileURL = sourceFileURL
         self.asset = AVURLAsset(URL: sourceFileURL, options: nil)
@@ -128,8 +138,12 @@ public struct Regift {
     public init(sourceFileURL: NSURL, startTime: Float, duration: Float, frameRate: Int, loopCount: Int = 0) {
         self.init(sourceFileURL: sourceFileURL, destinationFileURL: nil, startTime: startTime, duration: duration, frameRate: frameRate, loopCount: loopCount)
     }
-    
-    /// Get the URL of the GIF created with the attributes provided in the initializer.
+
+    /**
+        Get the URL of the GIF created with the attributes provided in the initializer.
+
+        - returns: The path to the created GIF, or `nil` if there was an error creating it.
+    */
     public func createGif() -> NSURL? {
 
         let fileProperties = [kCGImagePropertyGIFDictionary as String:[
@@ -163,13 +177,18 @@ public struct Regift {
             return nil
         }
     }
+
+    /**
+        Create a GIF using the given time points in a movie file stored in this Regift's `asset`.
     
-    /// Create a GIF using the given time points in a movie file stored at the URL provided.
-    ///
-    /// :param: timePoints An array of `TimePoint`s (which are typealiased `CMTime`s) to use as the frames in the GIF.
-    /// :param: URL The URL of the video file to convert
-    /// :param: fileProperties The desired attributes of the resulting GIF.
-    /// :param: frameProperties The desired attributes of each frame in the resulting GIF.
+        - parameters:
+            - timePoints: timePoints An array of `TimePoint`s (which are typealiased `CMTime`s) to use as the frames in the GIF.
+            - fileProperties: The desired attributes of the resulting GIF.
+            - frameProperties: The desired attributes of each frame in the resulting GIF.
+            - frameCount: The desired number of frames for the GIF. *NOTE: This seems redundant to me, as `timePoints.count` should really be what we are after, but I'm hesitant to change the API here.*
+
+        - returns: The path to the created GIF, or `nil` if there was an error creating it.
+    */
     public func createGIFForTimePoints(timePoints: [TimePoint], fileProperties: [String: AnyObject], frameProperties: [String: AnyObject], frameCount: Int) throws -> NSURL {
         // Ensure the source media is a valid file.
         guard asset.tracksWithMediaCharacteristic(AVMediaCharacteristicVisual).count > 0 else {

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -41,6 +41,11 @@ private struct Group {
 ///      let regift = Regift(sourceFileURL: movieFileURL, frameCount: 24, delayTime: 0.5, loopCount: 7)
 ///      print(regift.createGif())
 ///
+///      // OR
+///
+///      let trimmedRegift = Regift(sourceFileURL: movieFileURL, startTime: 30, duration: 15, frameRate: 15)
+///      print(trimmedRegift.createGif())
+///
 public struct Regift {
     private struct Constants {
         static let FileName = "regift.gif"
@@ -90,9 +95,38 @@ public struct Regift {
         self.destinationFileURL = destinationFileURL
         self.frameCount = frameCount
     }
+
+    /// Create a GIF from a movie stored at the given URL, trimmed to a specific section.
+    ///
+    /// :param: startTime The time at which to start the gif, trimmed out of the source file.
+    /// :param: duration The length of time from startTime to include in the trimmed file.
+    /// :param: frameRate The framerate desired for the resultant gif.
+    /// :param: loopCount The number of times the GIF will repeat. This defaults to 0, which means that the GIF will repeat infinitely.
+    public init(sourceFileURL: NSURL, destinationFileURL: NSURL?, startTime: Float, duration: Float, frameRate: Int, loopCount: Int = 0) {
+        self.sourceFileURL = sourceFileURL
+        self.asset = AVURLAsset(URL: sourceFileURL, options: nil)
+        self.destinationFileURL = destinationFileURL
+        self.startTime = startTime
+        self.duration = duration
+
+        // The delay time is based on the desired framerate of the gif.
+        self.delayTime = (1.0 / Float(frameRate))
+
+        // The frame count is based on the desired length and framerate of the gif.
+        self.frameCount = Int(duration * Float(frameRate))
+
+        // The total length of the file, in seconds.
+        self.movieLength = Float(asset.duration.value) / Float(asset.duration.timescale)
+
+        self.loopCount = loopCount
+    }
     
     public init(sourceFileURL: NSURL, frameCount: Int, delayTime: Float, loopCount: Int = 0) {
         self.init(sourceFileURL:sourceFileURL, destinationFileURL:nil, frameCount:frameCount, delayTime:delayTime, loopCount:loopCount)
+    }
+
+    public init(sourceFileURL: NSURL, startTime: Float, duration: Float, frameRate: Int, loopCount: Int = 0) {
+        self.init(sourceFileURL: sourceFileURL, destinationFileURL: nil, startTime: startTime, duration: duration, frameRate: frameRate, loopCount: loopCount)
     }
     
     /// Get the URL of the GIF created with the attributes provided in the initializer.

--- a/RegiftTests/RegiftTests.swift
+++ b/RegiftTests/RegiftTests.swift
@@ -70,7 +70,19 @@ class RegiftTests: XCTestCase {
         XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(result!.path!))
         
     }
-    
+
+    func testTrimmedGIFIsSaved() {
+
+        let savedURL = NSURL(fileURLWithPath: (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent("test_trim.gif"))
+        let regift = Regift(sourceFileURL: URL, destinationFileURL: savedURL, startTime: 1, duration: 2, frameRate: 15)
+        let result = regift.createGif()
+        XCTAssertNotNil(result, "The GIF URL should not be nil")
+
+        XCTAssertTrue(savedURL.absoluteString == result?.absoluteString)
+        XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(result!.path!))
+
+    }
+
     func testGIFIsNotCreated() {
         let regift = Regift(sourceFileURL: NSURL(), frameCount: 10, delayTime: 0.5)
         let result = regift.createGif()


### PR DESCRIPTION
This includes a number of bigger changes, so if you want any of it broken off or merged in separately, just let me know and I can split this apart. I tried to avoid modifying the existing API so as not to break anything for anyone. Here is a summary of what changed:
- Add the ability to generate a GIF based off of a subset of the video (e.g., take from 0:30 to 0:45 and make a GIF of that).
- Add static convenience methods which allow for asynchronous generation.
- Modify the generator to use a more efficient method, decreasing generation time on average about ~40%.
- Update the documentation to make use of a standard header style.

Feedback and questions are, of course, welcome....Thanks for creating this library, it's saved me a lot of time!
