### PR TITLE
avoid crash

### DIFF
--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -293,19 +293,11 @@ public struct Regift {
 
         // Create a dispatch group to force synchronous behavior on an asynchronous method.
         let gifGroup = Group()
-        var dispatchError: Bool = false
         gifGroup.enter()
 
         generator.generateCGImagesAsynchronously(forTimes: times, completionHandler: { (requestedTime, image, actualTime, result, error) in
-            // if not return when error occured and the time is the last time, gifGroup.leave() will get crash
-            guard !dispatchError else {
-                return
-            }
-            
             guard let imageRef = image , error == nil else {
                 print("An error occurred: \(error), image is \(image)")
-                dispatchError = true
-                gifGroup.leave()
                 return
             }
 
@@ -318,11 +310,6 @@ public struct Regift {
 
         // Wait for the asynchronous generator to finish.
         gifGroup.wait()
-
-        // If there was an error in the generator, throw the error.
-        if dispatchError {
-            throw RegiftError.AddFrameToDestination
-        }
         
         CGImageDestinationSetProperties(destination, fileProperties as CFDictionary)
         

--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -297,6 +297,11 @@ public struct Regift {
         gifGroup.enter()
 
         generator.generateCGImagesAsynchronously(forTimes: times, completionHandler: { (requestedTime, image, actualTime, result, error) in
+            // if not return when error occured and the time is the last time, gifGroup.leave() will get crash
+            guard !dispatchError else {
+                return
+            }
+            
             guard let imageRef = image , error == nil else {
                 print("An error occurred: \(error), image is \(image)")
                 dispatchError = true


### PR DESCRIPTION
when an error occur the giftGroup will been leaved, but the loop will continue. Finally at the last time the code will be execute giftGroup.leave() this will crash