### PR TITLE
Remove excess line.

### DIFF
--- a/Regift/Regift.swift
+++ b/Regift/Regift.swift
@@ -379,8 +379,6 @@ public struct Regift {
         // Wait for the asynchronous generator to finish.
         gifGroup.wait()
         
-        CGImageDestinationSetProperties(destination, fileProperties as CFDictionary)
-        
         // Finalize the gif
         if !CGImageDestinationFinalize(destination) {
             throw RegiftError.DestinationFinalize


### PR DESCRIPTION
CGImageDestinationSetProperties gives an error log because it was set after added images.
https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/ImageIOGuide/ikpg_dest/ikpg_dest.html